### PR TITLE
add .idea folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@ main.py
 scratch.*
 fts_index/
 
+# folder from intellij
+.idea
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
The .idea folder is Intellij/PyCharm specific. While there is some discussion on whether (parts of) the folder should be under version control, I think its better to remove it from version control.